### PR TITLE
Replace sklearn with scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     
     packages = ['ImbalancedLearningRegression'],
     include_package_data = True,
-    install_requires = ['numpy', 'pandas', 'tqdm', 'sklearn'],
+    install_requires = ['numpy', 'pandas', 'tqdm', 'scikit-learn'],
 )


### PR DESCRIPTION
sklearn was deprecated (see https://pypi.org/project/sklearn/).

Thanks for this library!